### PR TITLE
Dont repeat words

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **ElixirTerminalWordle** allows you to play a version of ``Wordle`` where all the **words are related to Elixir**.
 
-Do you dare to try a game? :) 
+Do you dare to try a game? :)
 
 ![Example of match](images/Exampleofgame.png)
 
@@ -12,7 +12,7 @@ Do you dare to try a game? :)
 
 - **Step 1**: Install [Elixir](https://elixir-lang.org/install.html). As a prerequisite for elixir installation, you have to have [Erlang](https://www.erlang.org/downloads.html) installed (> 0.23).
 
-- **Step 2**: Download the project. 
+- **Step 2**: Download the project.
   - `git clone https://github.com/IciaCarroBarallobre/ElixirTerminalWordle`
 - **Step 3**: Go to the project folder and install Mix dependencies.
   - 1. Go to the project folder:

--- a/lib/gen_server_words.ex
+++ b/lib/gen_server_words.ex
@@ -1,0 +1,49 @@
+defmodule WordleTerminalGame.GenServerWords do
+  use GenServer
+  alias WordleTerminalGame.{Words}
+
+  @moduledoc """
+  GenServerWords is a GenServer API which contains as a state a MapSet of Words.
+
+  A word is a tuple composed of {answer, explanation, clue}.
+
+  Its functionality is to return a random word and deleting this word
+  from state, the MapSet of Words.
+  """
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  @doc """
+  Returns a word which is deleted from the state.
+  In case of state was empty, returns nil.
+  """
+  def pop(pid) do
+    GenServer.call(pid, :pop)
+  end
+
+  @doc false
+  def get(pid) do
+    GenServer.call(pid, :get)
+  end
+
+  # Server callbacks
+  @impl true
+  def handle_call(:pop, _from, state) do
+    {chosen_word, new_state} = Words.pop(state)
+    {:reply, chosen_word, new_state}
+  end
+
+  # Server callbacks
+  @impl true
+  def handle_call(:get, _from, state) do
+    {:reply, state, state}
+  end
+
+  @impl true
+  @spec init(any) :: {:ok, MapSet.t({binary, binary, binary})}
+  def init(_opts) do
+    available_words = Words.create()
+    {:ok, available_words}
+  end
+end

--- a/lib/wordle-terminal-game.ex
+++ b/lib/wordle-terminal-game.ex
@@ -33,9 +33,9 @@ defmodule WordleTerminalGame do
   defp guess_the_answer(answer, explanation) do
     colorized_answer = IO.ANSI.green() <> answer <> IO.ANSI.reset()
     IO.puts("Right!! The answer is #{colorized_answer}.")
-    :timer.sleep(1000);
+    :timer.sleep(1000)
     IO.puts("Did you know that ... #{explanation} \n")
-    :timer.sleep(1000);
+    :timer.sleep(1000)
   end
 
   @doc """
@@ -51,8 +51,8 @@ defmodule WordleTerminalGame do
        - ... without **correct format** input: The function shows you the error.
        - ... answering **exit**: end the game.
   """
-  @spec play(binary, binary, binary) :: :ok
-  def play(answer, explanation, clue) do
+  @spec play(binary, binary, binary, pid) :: :ok
+  def play(answer, explanation, clue, pid) do
     guess =
       IO.gets("Contains #{String.length(answer)} letters, and a clue is `#{clue}`: ")
       |> String.replace("\n", "", trim: true)
@@ -64,17 +64,17 @@ defmodule WordleTerminalGame do
       case response do
         {:error, msg} ->
           IO.puts("Error: " <> msg)
-          play(answer, explanation, clue)
+          play(answer, explanation, clue, pid)
 
         {:ok, result} ->
           colorized_result = colorize(result, guess)
 
           if Enum.all?(result, fn x -> x == :green end) do
             guess_the_answer(guess, explanation)
-            start()
+            start(pid)
           else
             IO.puts("#{colorized_result}")
-            play(answer, explanation, clue)
+            play(answer, explanation, clue, pid)
           end
       end
     end
@@ -109,6 +109,11 @@ defmodule WordleTerminalGame do
   - Answering other things, return you to the same function but with helpful information.
   """
   def start() do
+    {:ok, pid} = Words.start_link([])
+    start(pid)
+  end
+
+  def start(pid) do
     IO.puts("-------------------------------------")
     IO.puts("----- ELIXIR SHELL WORDLE GAME ------")
     IO.puts("-------------------------------------")
@@ -124,13 +129,19 @@ defmodule WordleTerminalGame do
         :ok
 
       "y" ->
-        explain_rules()
-        {answer, answer_explanation, clue} = Words.get() |> Enum.random()
-        play(answer, answer_explanation, clue)
+        result = Words.pop(pid)
+
+        unless result == nil do
+          explain_rules()
+          {answer, answer_explanation, clue} = result
+          play(answer, answer_explanation, clue, pid)
+        else
+          IO.puts("I haven't got more guessing words! :(")
+        end
 
       _ ->
         IO.puts("I don't understand you, type yes or no.")
-        start()
+        start(pid)
     end
   end
 end

--- a/lib/wordle_terminal_game.ex
+++ b/lib/wordle_terminal_game.ex
@@ -1,5 +1,5 @@
 defmodule WordleTerminalGame do
-  alias WordleTerminalGame.{Wordle, Words}
+  alias WordleTerminalGame.{Wordle, GenServerWords}
 
   @moduledoc """
   This module contains a function ('start/0') to play Wordle with words
@@ -109,7 +109,7 @@ defmodule WordleTerminalGame do
   - Answering other things, return you to the same function but with helpful information.
   """
   def start() do
-    {:ok, pid} = Words.start_link([])
+    {:ok, pid} = GenServerWords.start_link([])
     start(pid)
   end
 
@@ -129,14 +129,14 @@ defmodule WordleTerminalGame do
         :ok
 
       "y" ->
-        result = Words.pop(pid)
+        result = GenServerWords.pop(pid)
 
         unless result == nil do
           explain_rules()
           {answer, answer_explanation, clue} = result
           play(answer, answer_explanation, clue, pid)
         else
-          IO.puts("I haven't got more guessing words! :(")
+          IO.puts("Sorry, I haven't got more guessing words! :(")
         end
 
       _ ->

--- a/lib/words.ex
+++ b/lib/words.ex
@@ -1,47 +1,67 @@
 defmodule WordleTerminalGame.Words do
+  use GenServer
+
   @moduledoc """
-  Words has a module attribute which is a list that contains tuples of three elements ``(answer, explanation, clue)``.
-  - The first element of the tuple, is the Wordle answer.
-  - The second element of the tuple, is a detail about the answer.
-  - The third element of the tuple, is a clue about the answer.
+  Words is a GenServer Callback Module which contains a MapSet.
+  Its functionality is return a random element and delete this element from the MapSet.
+
+  In our case element is a tuple composed of {word, explanation, clue}.
   """
-  @available_words [
-    {"elixir",
-     "Elixir is a dynamic, functional language for building scalable and maintainable applications.
-      It runs on the Erlang VM, known for creating low-latency, distributed, and fault-tolerant systems.",
-     "It's a language."},
-    {"erlang",
-     "Erlang is a programming language used to build massively scalable soft real-time systems with requirements
-      on high availability. It runs on the Erlang VM, same as Elixir.", "It's a language."},
-    {"strings", "Strings in Elixir are UTF-8 encoded binaries.", "Data type."},
-    {"floats",
-     " Floats (floating points) are not useful for representing money because cannot be stored exactly as it is in the memory.
-      You could use instead Integers.", "Data Type"},
-    {"enum",
-     "Enum module provides a set of algorithms to work with enumerables (such as lists, maps and ranges).",
-     "A Module"},
-    {"livebook",
-     "Livebook is an app to write interactive & collaborative code notebooks in Elixir.",
-     "You can create notebooks with it."},
-    {"mix",
-     "Mix is a build tool that ships with Elixir that provides tasks for creating, compiling,
-     testing your application, managing its dependencies and much more.", "Build tool."},
-    {"iex", "IEx is the Elixir interactive shell.", "A shell."},
-    {"exunit", "ExUnit is a testing framework for Elixir. ", "A framework for testing."},
-    {"exdoc",
-     "`mix docs` uses ExDoc to generate a static web page from the project documentation.",
-     "A framework for documentation."}
-    # TODO: Add more words
-  ]
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [])
+  end
 
   @doc """
-  Returns a list of tuples, its first element is a word related with Elixir,
-  its second element is a detail/comment about the word and,
-  its third element is a clue to guess the word.
+  Returns a
   """
+  def pop(pid) do
+    GenServer.call(pid, :pop)
+  end
 
-  @spec get :: [{binary, binary, binary}]
-  def get() do
-    @available_words
+  # Server callbacks
+  @impl true
+  def handle_call(:pop, _from, state) do
+    unless Enum.empty?(state) do
+      chosen_word = Enum.random(state)
+      new_state = MapSet.delete(state, chosen_word)
+      {:reply, chosen_word, new_state}
+    else
+      {:reply, nil, state}
+    end
+  end
+
+  @impl true
+  def init(_opts) do
+    available_words =
+      MapSet.new([
+        {"elixir",
+         "Elixir is a dynamic, functional language for building scalable and maintainable applications.
+        It runs on the Erlang VM, known for creating low-latency, distributed, and fault-tolerant systems.",
+         "It's a language."},
+        {"erlang",
+         "Erlang is a programming language used to build massively scalable soft real-time systems with requirements
+          on high availability. It runs on the Erlang VM, same as Elixir.", "It's a language."},
+        {"strings", "Strings in Elixir are UTF-8 encoded binaries.", "Data type."},
+        {"floats",
+         " Floats (floating points) are not useful for representing money because cannot be stored exactly as it is in the memory.
+          You could use instead Integers.", "Data Type"},
+        {"enum",
+         "Enum module provides a set of algorithms to work with enumerables (such as lists, maps and ranges).",
+         "A Module"},
+        {"livebook",
+         "Livebook is an app to write interactive & collaborative code notebooks in Elixir.",
+         "You can create notebooks with it."},
+        {"mix",
+         "Mix is a build tool that ships with Elixir that provides tasks for creating, compiling,
+         testing your application, managing its dependencies and much more.", "Build tool."},
+        {"iex", "IEx is the Elixir interactive shell.", "A shell."},
+        {"exunit", "ExUnit is a testing framework for Elixir. ", "A framework for testing."},
+        {"exdoc",
+         "`mix docs` uses ExDoc to generate a static web page from the project documentation.",
+         "A framework for documentation."}
+        # TODO: Add more words
+      ])
+
+    {:ok, available_words}
   end
 end

--- a/lib/words.ex
+++ b/lib/words.ex
@@ -1,67 +1,71 @@
 defmodule WordleTerminalGame.Words do
-  use GenServer
-
   @moduledoc """
-  Words is a GenServer Callback Module which contains a MapSet.
-  Its functionality is return a random element and delete this element from the MapSet.
+  Module that contains functions to create/0 a pre-define MapSet of Words,
+  where the order does not matter, with a pop/1 functionality, to get its elements.
 
-  In our case element is a tuple composed of {word, explanation, clue}.
+  A word is a tuple composed of {answer, explanation, clue}.
   """
-  def start_link(_opts) do
-    GenServer.start_link(__MODULE__, [])
+  @type words :: {binary, binary, binary}
+
+  @doc """
+  create/0 returns a MapSet of Words.
+  A Word is a tuple composed of {answer, explanation, clue}.
+  """
+  @spec create :: MapSet.t(words())
+  def create() do
+    MapSet.new([
+      {
+        "elixir",
+        "Elixir is a dynamic, functional language for building scalable and maintainable applications.
+    It runs on the Erlang VM, known for creating low-latency, distributed, and fault-tolerant systems.",
+        "It's a language."
+      },
+      {"erlang",
+       "Erlang is a programming language used to build massively scalable soft real-time systems with requirements
+        on high availability. It runs on the Erlang VM, same as Elixir.", "It's a language."},
+      {"strings", "Strings in Elixir are UTF-8 encoded binaries.", "Data type."},
+      {"floats",
+       " Floats (floating points) are not useful for representing money because cannot be stored exactly as it is in the memory.
+        You could use instead Integers.", "Data Type"},
+      {"enum",
+       "Enum module provides a set of algorithms to work with enumerables (such as lists, maps and ranges).",
+       "A Module"},
+      {"livebook",
+       "Livebook is an app to write interactive & collaborative code notebooks in Elixir.",
+       "You can create notebooks with it."},
+      {"mix",
+       "Mix is a build tool that ships with Elixir that provides tasks for creating, compiling,
+       testing your application, managing its dependencies and much more.", "Build tool."},
+      {"iex", "IEx is the Elixir interactive shell.", "A shell."},
+      {"exunit", "ExUnit is a testing framework for Elixir. ", "A framework for testing."},
+      {"exdoc",
+       "`mix docs` uses ExDoc to generate a static web page from the project documentation.",
+       "A framework for documentation."}
+      # TODO: Add more words
+    ])
   end
 
   @doc """
-  Returns a
+  The function pop/1, giving a MapSet, returns a tuple that contains
+  a random element of the MapSet and the same MapSet without the element.
+
+  ## Examples
+
+  iex> WordleTerminalGame.Words.pop(MapSet.new([1]))
+  {1, #MapSet<[]>}
+
+  iex> WordleTerminalGame.Words.pop(MapSet.new([]))
+  {nil, #MapSet<[]>}
+
   """
-  def pop(pid) do
-    GenServer.call(pid, :pop)
-  end
-
-  # Server callbacks
-  @impl true
-  def handle_call(:pop, _from, state) do
-    unless Enum.empty?(state) do
-      chosen_word = Enum.random(state)
-      new_state = MapSet.delete(state, chosen_word)
-      {:reply, chosen_word, new_state}
+  @spec pop(MapSet.t(any())) :: {any(), MapSet.t(any())}
+  def pop(words) do
+    unless Enum.empty?(words) do
+      chosen_word = Enum.random(words)
+      new_words = MapSet.delete(words, chosen_word)
+      {chosen_word, new_words}
     else
-      {:reply, nil, state}
+      {nil, words}
     end
-  end
-
-  @impl true
-  def init(_opts) do
-    available_words =
-      MapSet.new([
-        {"elixir",
-         "Elixir is a dynamic, functional language for building scalable and maintainable applications.
-        It runs on the Erlang VM, known for creating low-latency, distributed, and fault-tolerant systems.",
-         "It's a language."},
-        {"erlang",
-         "Erlang is a programming language used to build massively scalable soft real-time systems with requirements
-          on high availability. It runs on the Erlang VM, same as Elixir.", "It's a language."},
-        {"strings", "Strings in Elixir are UTF-8 encoded binaries.", "Data type."},
-        {"floats",
-         " Floats (floating points) are not useful for representing money because cannot be stored exactly as it is in the memory.
-          You could use instead Integers.", "Data Type"},
-        {"enum",
-         "Enum module provides a set of algorithms to work with enumerables (such as lists, maps and ranges).",
-         "A Module"},
-        {"livebook",
-         "Livebook is an app to write interactive & collaborative code notebooks in Elixir.",
-         "You can create notebooks with it."},
-        {"mix",
-         "Mix is a build tool that ships with Elixir that provides tasks for creating, compiling,
-         testing your application, managing its dependencies and much more.", "Build tool."},
-        {"iex", "IEx is the Elixir interactive shell.", "A shell."},
-        {"exunit", "ExUnit is a testing framework for Elixir. ", "A framework for testing."},
-        {"exdoc",
-         "`mix docs` uses ExDoc to generate a static web page from the project documentation.",
-         "A framework for documentation."}
-        # TODO: Add more words
-      ])
-
-    {:ok, available_words}
   end
 end

--- a/test/gen_server_words_test.exs
+++ b/test/gen_server_words_test.exs
@@ -1,0 +1,28 @@
+defmodule WordleTerminalGame.GenServerWordsTest do
+  use ExUnit.Case, async: true
+  alias WordleTerminalGame.GenServerWords, as: GenServerWords
+
+  setup do
+    {:ok, pid} = start_supervised(GenServerWords)
+    %{words_pid: pid}
+  end
+
+  describe "start_link/1" do
+    test "Always start with a predefine list", %{words_pid: pid} do
+      assert not Enum.empty?(GenServerWords.get(pid))
+    end
+  end
+
+  describe "pop/1" do
+    test "Return and remove the element from the state", %{words_pid: pid} do
+
+      element = GenServerWords.pop(pid)
+      assert not Enum.member?(GenServerWords.get(pid), element)
+    end
+
+    test "Return nil if state is empty", %{words_pid: pid} do
+      for _i <- GenServerWords.get(pid), do: GenServerWords.pop(pid)
+      assert nil == GenServerWords.pop(pid)
+    end
+  end
+end


### PR DESCRIPTION
**Problem or feature description**
Change Words Module which uses a module attribute (static) into 2 modules: GenServerWords and Words Logic. This allows us to remove elements from the word list and to keep a state, avoiding duplicates. 

**Issues solved**
- https://github.com/IciaCarroBarallobre/ElixirTerminalWordle/issues/2